### PR TITLE
update build command to prefix paths ;B

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "analyze:lint": "eslint --ext .jsx --ext .js .",
     "analyze:prettier": "prettier --list-different '**/*.{js,css,md,json}'",
     "analyze": "yarn run analyze:lint && yarn run analyze:prettier",
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "fix:lint": "eslint --ext .jsx --ext .js . --fix",
     "fix:prettier": "prettier --write '**/*.{js,css,md,json}'",


### PR DESCRIPTION
# Bug Fix

## Description

The build command did not use the `--prefix-paths` flag, which caused the assets to break again. This PR fixes that.

Fixes #33

## Checklist

- [x] My code follows the style guidelines of this project
- [x] The build is passing
- [x] I have tested my feature using the Netlify preview
- [x] I have added `;F`, `;B`, or `;M` to the title to indicate what type of PR this is
